### PR TITLE
Add HashRepresentation

### DIFF
--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -43,6 +43,10 @@ part "../src/serialization/bitcoin_serializable.dart";
 part "../src/serialization/bitcoin_serialization.dart";
 part "../src/serialization/serialization_exception.dart";
 
+// hash representation
+part "../src/hash/hash_representable.dart";
+part "../src/hash/hash_representation.dart";
+
 // addresses and private keys
 part "../src/core/address.dart";
 part "../src/core/base58check.dart";

--- a/lib/src/core/block.dart
+++ b/lib/src/core/block.dart
@@ -1,6 +1,6 @@
 part of dartcoin.core;
 
-class Block extends Object with BitcoinSerialization {
+class Block extends Object with HashRepresentable, BitcoinSerialization {
   
   static const int BLOCK_VERSION = 1;
   
@@ -434,16 +434,6 @@ class Block extends Object with BitcoinSerialization {
       _nonce++;
     }
   }
-  
-  @override
-  bool operator ==(Block other) {
-    if(other is! Block) return false;
-    if(identical(this, other)) return true;
-    return hash == other.hash;
-  }
-  
-  @override
-  int get hashCode => hash.hashCode;
   
   Uint8List _serializeHeader() {
     return new Uint8List.fromList(new List<int>()

--- a/lib/src/core/filtered_block.dart
+++ b/lib/src/core/filtered_block.dart
@@ -1,6 +1,6 @@
 part of dartcoin.core;
 
-class FilteredBlock extends Object with BitcoinSerialization {
+class FilteredBlock extends Object with HashRepresentable, BitcoinSerialization {
   /** The protocol version at which Bloom filtering started to be supported. */
   static const int MIN_PROTOCOL_VERSION = 70000;
   

--- a/lib/src/core/transaction.dart
+++ b/lib/src/core/transaction.dart
@@ -1,6 +1,6 @@
 part of dartcoin.core;
 
-class Transaction extends Object with BitcoinSerialization {
+class Transaction extends Object with HashRepresentable, BitcoinSerialization {
   
   static const int TRANSACTION_VERSION = 1;
   
@@ -236,16 +236,6 @@ class Transaction extends Object with BitcoinSerialization {
           throw new VerificationException("Coinbase input as input in non-coinbase transaction");
     }
   }
-  
-  @override
-  operator ==(Transaction other) {
-    if(other is! Transaction) return false;
-    if(identical(this, other)) return true;
-    return hash == other.hash;
-  }
-  
-  @override
-  int get hashCode => hash.hashCode;
   
   /**
    * 

--- a/lib/src/hash/hash_representable.dart
+++ b/lib/src/hash/hash_representable.dart
@@ -1,0 +1,23 @@
+part of dartcoin.core;
+
+
+/**
+ * This mixin is intended to be implemented by objects that
+ * can be represented by a hash.
+ */
+abstract class HashRepresentable {
+  
+  Sha256Hash get hash;
+  
+  bool get isHashOnly => false;
+  
+  @override
+  bool operator ==(HashRepresentable other) {
+    if(other is! HashRepresentable) return false;
+    return hash == other.hash;
+  }
+  
+  @override
+  int get hashCode => hash.hashCode;
+  
+}

--- a/lib/src/hash/hash_representation.dart
+++ b/lib/src/hash/hash_representation.dart
@@ -1,0 +1,32 @@
+part of dartcoin.core;
+
+/**
+ * Intended to be used as superclass of classes that are hash representations 
+ * of objects of another class.
+ */
+class HashRepresentation extends HashRepresentable {
+  
+  final Sha256Hash hash;
+  
+  HashRepresentation(Sha256Hash this.hash);
+  HashRepresentation.from(HashRepresentable from) : this(from.hash);
+  
+  bool get isHashOnly => true;
+  
+  @override
+  void noSuchMethod(Invocation invocation) => null;
+}
+
+class BlockHash extends HashRepresentation implements Block {
+  BlockHash(Sha256Hash hash) : super(hash);
+  BlockHash.from(Block block) : this(block.hash);
+  @override
+  void noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class TransactionHash extends HashRepresentation implements Transaction {
+  TransactionHash(Sha256Hash hash) : super(hash);
+  TransactionHash.from(Transaction tx) : this(tx.hash);
+  @override
+  void noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -15,6 +15,9 @@ import "crypto/key_crypter_scrypt_test.dart" as key_crypter_scrypt;
 // serialization
 import "serialization/varint_test.dart" as varint; 
 
+// hash representation
+import "hash/hash_representation_test.dart" as hash_representation;
+
 // wire
 import "wire/bloom_filter_test.dart" as bloom_filter;
 import "wire/message_serialization_test.dart" as message_serialization;
@@ -35,6 +38,8 @@ void main() {
   // TODO not yet working key_crypter_scrypt.main();
   // serialization
   varint.main();
+  // hash representation
+  hash_representation.main();
   // wire
   bloom_filter.main();
   message_serialization.main();

--- a/test/hash/hash_representation_test.dart
+++ b/test/hash/hash_representation_test.dart
@@ -1,0 +1,58 @@
+library dartcoin.test.hash.hash_representation;
+
+import "package:unittest/unittest.dart";
+
+import "package:dartcoin/core/core.dart";
+
+
+Transaction tx;
+Transaction fake;
+Transaction fake2;
+
+void _setUp() {
+  tx = new Transaction(txid: Sha256Hash.ZERO_HASH);
+  fake = new TransactionHash.from(tx);
+  fake2 = new TransactionHash(Sha256Hash.ZERO_HASH);
+}
+
+void _testEquals() {
+  expect(fake == tx, isTrue);
+  expect(tx == fake, isTrue);
+  expect(tx == fake2, isTrue);
+  expect(fake2 == tx, isTrue);
+  expect(fake.hashCode, equals(tx.hashCode));
+  expect(fake2.hashCode, equals(tx.hashCode));
+}
+
+void _testIsHashOnly() {
+  expect(tx.isHashOnly, isFalse);
+  expect(fake.isHashOnly, isTrue);
+}
+
+void _testCasting() {
+  expect(fake is Transaction, isTrue);
+}
+
+void _testMethodReplacer() {
+  expect(fake.inputs, isNull);
+  expect(fake2.serialize(), isNull);
+}
+
+void _testPlainHash() {
+  HashRepresentation hash = new HashRepresentation.from(tx);
+  
+  expect(hash == tx, isTrue);
+  expect(tx == hash, isTrue);
+  expect(hash is Transaction, isFalse);
+}
+
+void main() {
+  group("hash.HashRepresentation", () {
+    setUp(() => _setUp());
+    test("equals", () => _testEquals());
+    test("isHashOnly", () => _testIsHashOnly());
+    test("casting", () => _testCasting());
+    test("methodReplacer", () => _testMethodReplacer());
+    test("plain-hash", () => _testPlainHash());
+  });
+}


### PR DESCRIPTION
Make it possible to create objects that seem like real objects, but in fact only are a hash representation of the objects. Currently BlockHash and TransactionHash are supported. The == operator and the hashCode getter are implemented to only compare the hash so that a HashRepresentation appears equal to a real object.

I add this as a pull request because I'm not very sure myself if this is a good idea. Feedback wanted.
